### PR TITLE
add fhir init to add package.json and change # to @ at cache command

### DIFF
--- a/install-fhir-packages.sh
+++ b/install-fhir-packages.sh
@@ -56,7 +56,7 @@ $fhirCommand install $packageName $packageVersion | awk '{ print "\t" $0 }'
 
 echo "Checking if FHIR '$packageName' using version $packageVersion was successfully installed"
 packageNameWithoutDash=$(echo "$packageName" | sed -e "s/-/@/") # Temporary fix for FT 2.1.1, packages containing an '-' will show up with '@' in the cache
-$fhirCommand cache | grep -q $packageNameWithoutDash#$packageVersion
+$fhirCommand cache | grep -q $packageNameWithoutDash@$packageVersion
 if [ $? -eq 1 ]; then
     exit_with_message "Failed to install package $packageName using version $packageVersion"
 else

--- a/install-fhir-packages.sh
+++ b/install-fhir-packages.sh
@@ -61,6 +61,8 @@ if [ $? -eq 1 ]; then
     exit_with_message "Failed to install package $packageName using version $packageVersion"
 else
     echo -e "\t Successfully found package '$packageName' with version '$packageVersion' in cache"
+    #Generate a FHIR package manifest if not present
+    $fhirCommand init
 fi
 
 canonicals=$($fhirCommand canonicals $packageName $packageVersion)


### PR DESCRIPTION
without package.json the FT will search for the package in other folders, it'll end up in ~/.Trash 

and I've changed # to @: <package>@<version>